### PR TITLE
Fix for java.security.SignatureException: Signature length not correct

### DIFF
--- a/google-api-client/src/main/java/com/google/api/client/googleapis/auth/oauth2/GoogleIdTokenVerifier.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/auth/oauth2/GoogleIdTokenVerifier.java
@@ -171,8 +171,12 @@ public class GoogleIdTokenVerifier extends IdTokenVerifier {
     }
     // verify signature
     for (PublicKey publicKey : publicKeys.getPublicKeys()) {
-      if (googleIdToken.verifySignature(publicKey)) {
-        return true;
+      try {
+        if (googleIdToken.verifySignature(publicKey)) {
+          return true;
+        }
+      } catch (Exception e) {
+        System.err.println("Verify Token:" + e);
       }
     }
     return false;


### PR DESCRIPTION
Since a few hour ago, oath integration with google is not working because a exception `java.security.SignatureException: Signature length not correct: got 256 but was expecting 128`

This solution is based on this comment http://stackoverflow.com/questions/30780407/google-oauth2-jwt-token-verification-exception
If a exception is thrown while checking keys, it returns false instead of break.
