### PR TITLE
Change lastBytePos to long in MediaHttpDownloader.setContentRange

### DIFF
--- a/google-api-client/src/main/java/com/google/api/client/googleapis/media/MediaHttpDownloader.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/media/MediaHttpDownloader.java
@@ -304,7 +304,7 @@ public final class MediaHttpDownloader {
    * @param lastBytePos The last byte position in the content range string.
    * @since 1.13
    */
-  public MediaHttpDownloader setContentRange(long firstBytePos, int lastBytePos) {
+  public MediaHttpDownloader setContentRange(long firstBytePos, long lastBytePos) {
     Preconditions.checkArgument(lastBytePos >= firstBytePos);
     setBytesDownloaded(firstBytePos);
     this.lastBytePos = lastBytePos;


### PR DESCRIPTION
This PR tries to fix #937.

This PR breaks `clirr` check with the following error:

> Parameter 2 of 'public com.google.api.client.googleapis.media.MediaHttpDownloader setContentRange(long, int)' has changed its type to long

I don't see any major issue with this as `MediaHttpDownloader.lastBytePos` field is already a `long`, but correct me if I'm wrong.
