### PR TITLE
Remove oraclejdk7 from travis build

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ env:
   - PATH="/tmp/proto$PROTO_VERSION/bin:$PATH"
 jdk:
   - oraclejdk8
-  - oraclejdk7
   - openjdk7
   - openjdk6
 before_install:


### PR DESCRIPTION
oraclejdk7 is no longer supported by Oracle and openjdk7 is pretty
similar.