### PR TITLE
Don't throw NPE on GoogleCredential.Builder when scopes not set

### DIFF
--- a/google-api-client/src/main/java/com/google/api/client/googleapis/auth/oauth2/GoogleCredential.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/auth/oauth2/GoogleCredential.java
@@ -318,7 +318,10 @@ public class GoogleCredential extends Credential {
           && builder.serviceAccountScopes == null && builder.serviceAccountUser == null);
     } else {
       serviceAccountId = Preconditions.checkNotNull(builder.serviceAccountId);
-      serviceAccountScopes = Collections.unmodifiableCollection(builder.serviceAccountScopes);
+      serviceAccountScopes =
+          (builder.serviceAccountScopes == null)
+              ? Collections.<String>emptyList()
+              : Collections.unmodifiableCollection(builder.serviceAccountScopes);
       serviceAccountPrivateKey = builder.serviceAccountPrivateKey;
       serviceAccountPrivateKeyId = builder.serviceAccountPrivateKeyId;
       serviceAccountUser = builder.serviceAccountUser;

--- a/google-api-client/src/test/java/com/google/api/client/googleapis/auth/oauth2/GoogleCredentialTest.java
+++ b/google-api-client/src/test/java/com/google/api/client/googleapis/auth/oauth2/GoogleCredentialTest.java
@@ -135,6 +135,24 @@ public class GoogleCredentialTest extends TestCase {
         scopedCredential.getServiceAccountPrivateKey());
   }
 
+  public void testCreateScopesNotSet() throws Exception {
+    final String serviceAccountEmail =
+        "36680232662-vrd7ji19q3ne0ah2csanun6bnr@developer.gserviceaccount.com";
+    final String accessToken = "1/MkSJoj1xsli0AccessToken_NKPY2";
+    MockTokenServerTransport transport = new MockTokenServerTransport();
+    transport.addServiceAccount(serviceAccountEmail, accessToken);
+
+    GoogleCredential credential = new GoogleCredential.Builder()
+        .setServiceAccountId(serviceAccountEmail)
+        .setServiceAccountPrivateKey(SecurityTestUtils.newRsaPrivateKey())
+        .setTransport(transport)
+        .setJsonFactory(JSON_FACTORY)
+        .build();
+    // Note that setServiceAccountScopes() is not called, so it is uninitialized (i.e. null) on the
+    // builder.
+    assertTrue(credential.getServiceAccountScopes().isEmpty());
+  }
+
   public void testGetApplicationDefaultNullTransportThrows() throws IOException {
     try {
       GoogleCredential.getApplicationDefault(null, JSON_FACTORY);


### PR DESCRIPTION
The list of account scopes in the GoogleCredential.Builder starts off
uninitialized (i.e. null), meaning that calling the .build() method
throws an NPE unless setServiceAccountScopes() is called.  There are no
other fields in the builder that are required to be called, and this
doesn't seem to be required intentionally, so make the Builder resilient
to it being null and have it correctly interpret that as an empty list
of scopes.
