### PR TITLE
add OSGI metadata

### DIFF
--- a/google-api-client/pom.xml
+++ b/google-api-client/pom.xml
@@ -36,19 +36,41 @@
         <configuration>
           <archive>
             <manifest>
-              <addDefaultImplementationEntries>true</addDefaultImplementationEntries>
+<addDefaultImplementationEntries>true</addDefaultImplementationEntries>
             </manifest>
+             <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
           </archive>
         </configuration>
         <executions>
           <execution>
             <id>jar</id>
-            <phase>compile</phase>
+            <phase>package</phase>
             <goals>
               <goal>jar</goal>
             </goals>
           </execution>
         </executions>
+      </plugin>
+      <plugin>   
+        <groupId>org.apache.felix</groupId>
+        <artifactId>maven-bundle-plugin</artifactId>
+        <version>2.5.4</version>
+        <executions>
+          <execution>
+            <id>bundle-manifest</id>
+            <phase>process-classes</phase>
+            <goals>    
+              <goal>manifest</goal>
+            </goals>   
+          </execution>
+        </executions>
+        <configuration>
+          <instructions>
+            <Bundle-DocURL>https://developers.google.com/api-client-library/java/</Bundle-DocURL>
+            <Bundle-Description>The Google API Client Library for Java provides functionality common to all Google APIs; for example HTTP transport, error handling, authentication, JSON parsing, media download/upload, and batching.</Bundle-Description>
+            <Bundle-SymbolicName>com.google.api.client.googleapis</Bundle-SymbolicName>
+          </instructions>
+        </configuration>
       </plugin>
       <plugin>
         <artifactId>maven-source-plugin</artifactId>

--- a/google-api-client/pom.xml
+++ b/google-api-client/pom.xml
@@ -41,15 +41,6 @@
              <manifestFile>${project.build.outputDirectory}/META-INF/MANIFEST.MF</manifestFile>
           </archive>
         </configuration>
-        <executions>
-          <execution>
-            <id>jar</id>
-            <phase>package</phase>
-            <goals>
-              <goal>jar</goal>
-            </goals>
-          </execution>
-        </executions>
       </plugin>
       <plugin>   
         <groupId>org.apache.felix</groupId>
@@ -77,7 +68,6 @@
         <executions>
           <execution>
             <id>source-jar</id>
-            <phase>compile</phase>
             <goals>
               <goal>jar</goal>
             </goals>


### PR DESCRIPTION
@briandealwis @chanseokoh @garrettjonesgoogle

Note especially that this PR moves the jar goal from the compile phase to the default package phase. Was there a reason this was in the compile phase? 