### PR TITLE
Possible Fix for AppIdentityCredentialWrapper.getAccessToken() Method

### DIFF
--- a/google-api-client-appengine/src/main/java/com/google/api/client/googleapis/extensions/appengine/auth/oauth2/AppIdentityCredential.java
+++ b/google-api-client-appengine/src/main/java/com/google/api/client/googleapis/extensions/appengine/auth/oauth2/AppIdentityCredential.java
@@ -15,6 +15,7 @@
 package com.google.api.client.googleapis.extensions.appengine.auth.oauth2;
 
 import com.google.api.client.auth.oauth2.BearerToken;
+import com.google.api.client.auth.oauth2.TokenResponse;
 import com.google.api.client.googleapis.auth.oauth2.GoogleCredential;
 import com.google.api.client.http.HttpExecuteInterceptor;
 import com.google.api.client.http.HttpRequest;
@@ -24,6 +25,7 @@ import com.google.api.client.json.JsonFactory;
 import com.google.api.client.util.Beta;
 import com.google.api.client.util.Preconditions;
 import com.google.appengine.api.appidentity.AppIdentityService;
+import com.google.appengine.api.appidentity.AppIdentityService.GetAccessTokenResult;
 import com.google.appengine.api.appidentity.AppIdentityServiceFactory;
 
 import java.io.IOException;
@@ -254,6 +256,18 @@ public class AppIdentityCredential implements HttpRequestInitializer, HttpExecut
               .build(),
           getTransport(),
           getJsonFactory());
+    }
+
+    @Override
+    protected TokenResponse executeRefreshToken() throws IOException {
+      GetAccessTokenResult tokenResult = appIdentity.getAppIdentityService()
+          .getAccessToken(appIdentity.getScopes());
+      TokenResponse response = new TokenResponse();
+      response.setAccessToken(tokenResult.getAccessToken());
+      long expiresInSeconds =
+          (tokenResult.getExpirationTime().getTime() - System.currentTimeMillis()) / 1000;
+      response.setExpiresInSeconds(expiresInSeconds);
+      return response;
     }
   }
 }

--- a/google-api-client-appengine/src/main/java/com/google/api/client/googleapis/extensions/appengine/testing/auth/oauth2/MockAppIdentityService.java
+++ b/google-api-client-appengine/src/main/java/com/google/api/client/googleapis/extensions/appengine/testing/auth/oauth2/MockAppIdentityService.java
@@ -20,6 +20,7 @@ import com.google.appengine.api.appidentity.AppIdentityServiceFailureException;
 import com.google.appengine.api.appidentity.PublicCertificate;
 
 import java.util.Collection;
+import java.util.Date;
 
 /**
  * {@link Beta} <br/>
@@ -70,7 +71,8 @@ public class MockAppIdentityService implements AppIdentityService {
     if (scopeCount == 0) {
       throw new AppIdentityServiceFailureException("No scopes specified.");
     }
-    return new GetAccessTokenResult(accessTokenText, null);
+    return new GetAccessTokenResult(accessTokenText,
+        new Date(System.currentTimeMillis() + 3600000));
   }
 
   @Override

--- a/google-api-client-appengine/src/test/java/com/google/api/client/googleapis/extensions/appengine/auth/oauth2/AppIdentityCredentialTest.java
+++ b/google-api-client-appengine/src/test/java/com/google/api/client/googleapis/extensions/appengine/auth/oauth2/AppIdentityCredentialTest.java
@@ -107,6 +107,25 @@ public class AppIdentityCredentialTest extends TestCase {
     assertTrue(authHeader.contains(expectedAccessToken));
   }
 
+  public void testAppEngineCredentialWrapperGetAccessToken() {
+    final String expectedAccessToken = "ExpectedAccessToken";
+    final Collection<String> emptyScopes = Collections.emptyList();
+
+    HttpTransport transport = new MockHttpTransport();
+    JsonFactory jsonFactory = new JacksonFactory();
+
+    MockAppIdentityService appIdentity = new MockAppIdentityService();
+    appIdentity.setAccessTokenText(expectedAccessToken);
+
+    AppIdentityCredential.Builder builder = new AppIdentityCredential.Builder(emptyScopes);
+    builder.setAppIdentityService(appIdentity);
+    AppIdentityCredential appCredential = builder.build();
+
+    GoogleCredential wrapper = new
+        AppIdentityCredential.AppEngineCredentialWrapper(appCredential, transport, jsonFactory);
+    assertEquals(expectedAccessToken, wrapper.getAccessToken());
+  }
+
   public void testAppEngineCredentialWrapperNullTransportThrows() throws IOException {
     JsonFactory jsonFactory = new JacksonFactory();
     try {

--- a/google-api-client-appengine/src/test/java/com/google/api/client/googleapis/extensions/appengine/auth/oauth2/AppIdentityCredentialTest.java
+++ b/google-api-client-appengine/src/test/java/com/google/api/client/googleapis/extensions/appengine/auth/oauth2/AppIdentityCredentialTest.java
@@ -107,9 +107,8 @@ public class AppIdentityCredentialTest extends TestCase {
     assertTrue(authHeader.contains(expectedAccessToken));
   }
 
-  public void testAppEngineCredentialWrapperGetAccessToken() {
+  public void testAppEngineCredentialWrapperGetAccessToken() throws IOException {
     final String expectedAccessToken = "ExpectedAccessToken";
-    final Collection<String> emptyScopes = Collections.emptyList();
 
     HttpTransport transport = new MockHttpTransport();
     JsonFactory jsonFactory = new JacksonFactory();
@@ -117,12 +116,13 @@ public class AppIdentityCredentialTest extends TestCase {
     MockAppIdentityService appIdentity = new MockAppIdentityService();
     appIdentity.setAccessTokenText(expectedAccessToken);
 
-    AppIdentityCredential.Builder builder = new AppIdentityCredential.Builder(emptyScopes);
+    AppIdentityCredential.Builder builder = new AppIdentityCredential.Builder(SCOPES);
     builder.setAppIdentityService(appIdentity);
     AppIdentityCredential appCredential = builder.build();
 
     GoogleCredential wrapper = new
         AppIdentityCredential.AppEngineCredentialWrapper(appCredential, transport, jsonFactory);
+    assertTrue(wrapper.refreshToken());
     assertEquals(expectedAccessToken, wrapper.getAccessToken());
   }
 


### PR DESCRIPTION
This method currently always returns null in App Engine environment, which is a major problem when working with application default credentials. Also the associated `refreshToken()` method always returns false. This fix enables users to call `refreshToken()` and `getAccessToken()` on application default credentials in the App Engine environment. 

I'm not very familiar with this codebase, and hence it may not be complete or even fully accurate. Feedback appreciated.