### PR TITLE
Handle case when batchPath is null

### DIFF
--- a/google-api-client/src/main/java/com/google/api/client/googleapis/services/AbstractGoogleClient.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/services/AbstractGoogleClient.java
@@ -234,7 +234,7 @@ public abstract class AbstractGoogleClient {
   public final BatchRequest batch(HttpRequestInitializer httpRequestInitializer) {
     BatchRequest batch =
         new BatchRequest(getRequestFactory().getTransport(), httpRequestInitializer);
-    if (batchPath.length() == 0) {
+    if (Strings.isNullOrEmpty(batchPath)) {
       batch.setBatchUrl(new GenericUrl(getRootUrl() + "batch"));
     } else {
       batch.setBatchUrl(new GenericUrl(getRootUrl() + batchPath));


### PR DESCRIPTION
Fixes [#1073](https://github.com/google/google-api-java-client/issues/1073)

[#1087](https://github.com/google/google-api-java-client/pull/1087) aimed to fix this (and might have for some cases) but when I use it `batchPath` is `null` when not set and not an empty string.