### PR TITLE
Library security updates.

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -543,15 +543,15 @@
     <project.oauth.version>1.24.0-SNAPSHOT</project.oauth.version>
     <project.jsr305.version>3.0.2</project.jsr305.version>
     <project.gson.version>2.1</project.gson.version>
-    <project.jackson-core-asl.version>1.9.11</project.jackson-core-asl.version>
-    <project.jackson-core2.version>2.9.2</project.jackson-core2.version>
+    <project.jackson-core-asl.version>1.9.13</project.jackson-core-asl.version>
+    <project.jackson-core2.version>2.9.6</project.jackson-core2.version>
     <project.protobuf-java.version>2.6.1</project.protobuf-java.version>
     <project.guava.version>19.0</project.guava.version>
     <project.appengine.version>1.7.7</project.appengine.version>
     <project.xpp3.version>1.1.4c</project.xpp3.version>
     <project.commons-logging.version>1.1.1</project.commons-logging.version>
-    <project.httpclient.version>4.5.3</project.httpclient.version>
-    <project.httpcore.version>4.0.1</project.httpcore.version>
+    <project.httpclient.version>4.5.5</project.httpclient.version>
+    <project.httpcore.version>4.4.10</project.httpcore.version>
     <project.jdo2-api.version>2.3-eb</project.jdo2-api.version>
     <project.transaction-api.version>1.1</project.transaction-api.version>
   </properties>


### PR DESCRIPTION
Fixes https://github.com/google/google-api-java-client/issues/1084

httpclient 4.5.5
jackson 2.9.6

There are currently three public CVEs for httpclient 4.0.1.

Filename: httpclient-4.0.1.jar | Reference: CVE-2011-1498 | CVSS Score: 4.3 | Category: CWE-200 Information Exposure | Apache HttpClient 4.x before 4.1.1 in Apache HttpComponents, when used with an authenticating proxy server, sends the Proxy-Authorization header to the origin server, which allows remote web servers to obtain sensitive information by logging this header.

Filename: httpclient-4.0.1.jar | Reference: CVE-2014-3577 | CVSS Score: 5.8 | org.apache.http.conn.ssl.AbstractVerifier in Apache HttpComponents HttpClient before 4.3.5 and HttpAsyncClient before 4.0.2 does not properly verify that the server hostname matches a domain name in the subject's Common Name (CN) or subjectAltName field of the X.509 certificate, which allows man-in-the-middle attackers to spoof SSL servers via a "CN=" string in a field in the distinguished name (DN) of a certificate, as demonstrated by the "foo,CN=www.apache.org" string in the O field.

Filename: httpclient-4.0.1.jar | Reference: CVE-2015-5262 | CVSS Score: 4.3 | Category: CWE-399 Resource Management Errors | http/conn/ssl/SSLConnectionSocketFactory.java in Apache HttpComponents HttpClient before 4.3.6 ignores the http.socket.timeout configuration setting during an SSL handshake, which allows remote attackers to cause a denial of service (HTTPS call hang) via unspecified vectors.