### PR TITLE
revert runningOnAppEngine changes

### DIFF
--- a/google-api-client/src/main/java/com/google/api/client/googleapis/auth/oauth2/DefaultCredentialProvider.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/auth/oauth2/DefaultCredentialProvider.java
@@ -259,39 +259,24 @@ class DefaultCredentialProvider extends SystemEnvironmentProvider {
   }
 
   private boolean useGAEStandardAPI() {
-    // We should specifically return false in some cases in order to shortcircuit checking for
-    // appengine classpath resources. This lets us flow into metadata server logic rather than
-    // continuing to rely on jars on the classpath.
-    if (getEnvEquals("GAE_ENV", "standard")) {
-      return getEnvEquals("GAE_RUNTIME", "java7");
-    }
-    if (getEnvEquals("GAE_VM", "true")) {
-      return false;
-    }
-
-    // Check the classpath for the existence of classes.
-    Class<?> systemPropertyClass;
+    Class<?> systemPropertyClass = null;
     try {
       systemPropertyClass = forName("com.google.appengine.api.utils.SystemProperty");
     } catch (ClassNotFoundException expected) {
-      // We didn't find the class - move on.
+      // SystemProperty will always be present on App Engine.
       return false;
     }
-
     Exception cause = null;
     Field environmentField;
     try {
-      // Use reflection to call com.google.appengine.api.utils.SystemProperty::environment.value().
       environmentField = systemPropertyClass.getField("environment");
       Object environmentValue = environmentField.get(null);
       Class<?> environmentType = environmentField.getType();
       Method valueMethod = environmentType.getMethod("value");
       Object environmentValueValue = valueMethod.invoke(environmentValue);
-
-      // Any value will be treated as "running on app engine standard".
       return (environmentValueValue != null);
-    } catch (NoSuchFieldException ignored) {
-      // If the field does not exist then we treat it as false.
+    } catch (NoSuchFieldException exception) {
+      cause = exception;
     } catch (SecurityException exception) {
       cause = exception;
     } catch (IllegalArgumentException exception) {
@@ -303,14 +288,9 @@ class DefaultCredentialProvider extends SystemEnvironmentProvider {
     } catch (InvocationTargetException exception) {
       cause = exception;
     }
-
-    if (cause != null) {
-      throw new RuntimeException(String.format(
-          "Unexpected error trying to determine if runnning on Google App Engine: %s",
-          cause.getMessage()), cause);
-    }
-
-    return false;
+    throw OAuth2Utils.exceptionWithCause(new RuntimeException(String.format(
+        "Unexpcted error trying to determine if runnning on Google App Engine: %s",
+        cause.getMessage())), cause);
   }
 
   private final GoogleCredential getAppEngineCredential(


### PR DESCRIPTION
The method runningOnAppEngine was recently renamed to useGAEStandardAPI, and
its logic was changed in https://github.com/google/google-api-java-client/pull/1109 and https://github.com/google/google-api-java-client/commit/75ba03c89a4290fabbb66823f7037ff28ce5f4b9.

This PR reverts back to the original logic before either of those commits.

The reason for the revert is that several deployments failed with this change internally. See b/111173267, b/111149869.

This change has already been submitted internally. This PR simply syncs the internal change to external. See me for more details if you're curious. 