### PR TITLE
add jdo jar properties to android assembly

### DIFF
--- a/google-api-client-assembly/android-properties/google-http-client-jdo-1.24.0-SNAPSHOT.jar.properties
+++ b/google-api-client-assembly/android-properties/google-http-client-jdo-1.24.0-SNAPSHOT.jar.properties
@@ -1,0 +1,1 @@
+src=../libs-sources/google-http-client-jdo-${project.version}-sources.jar


### PR DESCRIPTION
When the assembly project is {compiled|deployed} (one of those two?), it generates sources. Among those sources are the google-http-java-client-jdo-<version>.jar file in libs-sources. This is fine, but the release process expects a .jar.properties file in libs/. This commit adds it.

Prior to this commit, people were scratching their heads during release and adding it manually.

ejona@ was the one that discovered the solution to this problem.