### PR TITLE
Add X-Goog-Api-Client header

### DIFF
--- a/google-api-client/src/main/java/com/google/api/client/googleapis/services/AbstractGoogleClientRequest.java
+++ b/google-api-client/src/main/java/com/google/api/client/googleapis/services/AbstractGoogleClientRequest.java
@@ -12,6 +12,7 @@
 
 package com.google.api.client.googleapis.services;
 
+import com.google.api.client.googleapis.GoogleUtils;
 import com.google.api.client.googleapis.MethodOverride;
 import com.google.api.client.googleapis.batch.BatchCallback;
 import com.google.api.client.googleapis.batch.BatchRequest;
@@ -37,6 +38,8 @@ import com.google.api.client.util.Preconditions;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 
 /**
  * Abstract Google client request for a {@link AbstractGoogleClient}.
@@ -58,6 +61,8 @@ public abstract class AbstractGoogleClientRequest<T> extends GenericData {
    * @since 1.20
    */
   public static final String USER_AGENT_SUFFIX = "Google-API-Java-Client";
+
+  private static final String API_VERSION_HEADER = "X-Goog-Api-Client";
 
   /** Google client. */
   private final AbstractGoogleClient abstractGoogleClient;
@@ -118,6 +123,48 @@ public abstract class AbstractGoogleClientRequest<T> extends GenericData {
       requestHeaders.setUserAgent(applicationName + " " + USER_AGENT_SUFFIX);
     } else {
       requestHeaders.setUserAgent(USER_AGENT_SUFFIX);
+    }
+    // Set the header for the Api Client version (Java and OS version)
+    requestHeaders.set(API_VERSION_HEADER, ApiClientVersion.build(abstractGoogleClient));
+  }
+
+  /**
+   * Internal class to help build the X-Goog-Api-Client header. This header identifies the
+   * API Client version and environment.
+   *
+   * See <a href="https://cloud.google.com/apis/docs/system-parameters"></a>
+   *
+   */
+  private static class ApiClientVersion {
+    private static final String JAVA_VERSION = formatSemver(System.getProperty("java.version"));
+    private static final String OS_NAME = formatName(System.getProperty("os.name"));
+    private static final String OS_VERSION = formatSemver(System.getProperty("os.version"));
+
+    private static String build(AbstractGoogleClient client) {
+      // TODO(chingor): add the API version from the generated client
+      return String.format(
+          "java/%s http-google-%s/%s %s/%s",
+          JAVA_VERSION,
+          formatName(client.getClass().getSimpleName()),
+          formatSemver(GoogleUtils.VERSION),
+          OS_NAME,
+          OS_VERSION
+      );
+    }
+
+    private static String formatName(String name) {
+      // Only lowercase letters, digits, and "-" are allowed
+      return name.toLowerCase().replaceAll("[^\\w\\d\\-]", "-");
+    }
+
+    private static String formatSemver(String version) {
+      // Take only the semver version: x.y.z-a_b_c -> x.y.z
+      Matcher m = Pattern.compile("(\\d+\\.\\d+\\.\\d+).*").matcher(version);
+      if (m.find()) {
+        return m.group(1);
+      } else {
+        return version;
+      }
     }
   }
 

--- a/google-api-client/src/test/java/com/google/api/client/googleapis/services/AbstractGoogleClientRequestTest.java
+++ b/google-api-client/src/test/java/com/google/api/client/googleapis/services/AbstractGoogleClientRequestTest.java
@@ -200,7 +200,7 @@ public class AbstractGoogleClientRequestTest extends TestCase {
   }
 
   public void testSetsApiClientHeader() throws Exception {
-    HttpTransport transport = new AssertHeaderTransport("X-Goog-Api-Client", "gl-java/\\d+\\.\\d+\\.\\d+.*");
+    HttpTransport transport = new AssertHeaderTransport("X-Goog-Api-Client", "java/\\d+\\.\\d+\\.\\d+.*");
     MockGoogleClient client = new MockGoogleClient.Builder(
         transport, ROOT_URL, SERVICE_PATH, JSON_OBJECT_PARSER, null).build();
     MockGoogleClientRequest<Void> request =

--- a/google-api-client/src/test/java/com/google/api/client/googleapis/services/AbstractGoogleClientRequestTest.java
+++ b/google-api-client/src/test/java/com/google/api/client/googleapis/services/AbstractGoogleClientRequestTest.java
@@ -175,7 +175,6 @@ public class AbstractGoogleClientRequestTest extends TestCase {
 
   public void testUserAgentSuffix() throws Exception {
     AssertUserAgentTransport transport = new AssertUserAgentTransport();
-
     // Specify an Application Name.
     String applicationName = "Test Application";
     transport.expectedUserAgent = applicationName + " "
@@ -187,15 +186,47 @@ public class AbstractGoogleClientRequestTest extends TestCase {
     MockGoogleClientRequest<Void> request =
         new MockGoogleClientRequest<Void>(client, HttpMethods.GET, URI_TEMPLATE, null, Void.class);
     request.executeUnparsed();
+  }
 
+  public void testUserAgent() throws Exception {
+    AssertUserAgentTransport transport = new AssertUserAgentTransport();
+    transport.expectedUserAgent = AbstractGoogleClientRequest.USER_AGENT_SUFFIX + " " + HttpRequest.USER_AGENT_SUFFIX;
     // Don't specify an Application Name.
-    transport.expectedUserAgent = AbstractGoogleClientRequest.USER_AGENT_SUFFIX + " "
-        + HttpRequest.USER_AGENT_SUFFIX;
-    client = new MockGoogleClient.Builder(
+    MockGoogleClient client = new MockGoogleClient.Builder(
         transport, ROOT_URL, SERVICE_PATH, JSON_OBJECT_PARSER, null).build();
-    request =
+    MockGoogleClientRequest<Void> request =
         new MockGoogleClientRequest<Void>(client, HttpMethods.GET, URI_TEMPLATE, null, Void.class);
     request.executeUnparsed();
+  }
+
+  public void testSetsApiClientHeader() throws Exception {
+    HttpTransport transport = new AssertHeaderTransport("X-Goog-Api-Client", "gl-java/\\d+\\.\\d+\\.\\d+.*");
+    MockGoogleClient client = new MockGoogleClient.Builder(
+        transport, ROOT_URL, SERVICE_PATH, JSON_OBJECT_PARSER, null).build();
+    MockGoogleClientRequest<Void> request =
+        new MockGoogleClientRequest<Void>(client, HttpMethods.GET, URI_TEMPLATE, null, Void.class);
+    request.executeUnparsed();
+  }
+
+  private class AssertHeaderTransport extends MockHttpTransport {
+    String expectedHeader;
+    String expectedHeaderValue;
+
+    AssertHeaderTransport(String header, String value) {
+      expectedHeader = header;
+      expectedHeaderValue = value;
+    }
+
+    @Override
+    public LowLevelHttpRequest buildRequest(String method, String url) throws IOException {
+      return new MockLowLevelHttpRequest() {
+        @Override
+        public LowLevelHttpResponse execute() throws IOException {
+          assertTrue(getFirstHeaderValue(expectedHeader).matches(expectedHeaderValue));
+          return new MockLowLevelHttpResponse();
+        }
+      };
+    }
   }
 
   private class AssertUserAgentTransport extends MockHttpTransport {


### PR DESCRIPTION
To get better visibility into which Java versions/environments users are using, we want to add a header to all API requests that identify the client's language version (and other relevant environment versions).

See https://cloud.google.com/apis/docs/system-parameters